### PR TITLE
feat(i18n): add Simplified Chinese localization

### DIFF
--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,666 @@
+{
+  "@@locale": "zh",
+  "languageName": "简体中文",
+  "@languageName": {
+    "description": "This language, written in itself. Shown in the language picker."
+  },
+  "vsLastMonthLabel": "较上月 {pct}%",
+  "@vsLastMonthLabel": {
+    "placeholders": {
+      "pct": {
+        "type": "String"
+      }
+    }
+  },
+  "levelStreakLabel": "等级 {level} · {streak}",
+  "@levelStreakLabel": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "streak": {
+        "type": "String"
+      }
+    }
+  },
+  "save": "保存",
+  "cancel": "取消",
+  "cancelCaps": "取消",
+  "deleteCaps": "删除",
+  "done": "完成",
+  "set": "组",
+  "home": "首页",
+  "progress": "进度",
+  "exercises": "动作",
+  "settings": "设置",
+  "today": "今天",
+  "thisWeek": "本周",
+  "recommended": "推荐",
+  "goal": "目标",
+  "volume": "训练量",
+  "setsToday": "今日组数",
+  "prs": "个人纪录",
+  "todaysFocus": "今日重点",
+  "todaysRoutine": "今日计划",
+  "startWorkout": "开始训练",
+  "routines": "训练计划",
+  "tools": "工具",
+  "firstSessionHint": "选择目标肌群并记录第一次训练",
+  "exerciseCount": "{n} 个动作",
+  "@exerciseCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "pushDay": "推日",
+  "pullDay": "拉日",
+  "legDay": "腿日",
+  "pushFocus": "胸 · 肩 · 肱三头肌",
+  "pullFocus": "背 · 肱二头肌 · 斜方肌",
+  "legFocus": "股四头肌 · 腘绳肌 · 臀肌",
+  "train": "训练",
+  "step1": "第 1 步，共 2 步",
+  "step2": "第 2 步，共 2 步",
+  "chooseFocus": "选择训练重点",
+  "buildSession": "生成本次训练",
+  "tapMuscles": "点击你想训练的肌群，可选择身体正面或背面。",
+  "noMusclesYet": "尚未选择肌群，点击身体开始。",
+  "continueBtn": "继续",
+  "nothingForFocus": "暂无适合该重点的内容",
+  "goBackPick": "返回并选择动作库中已有动作的肌群。",
+  "pickedHint": "已为你生成训练内容，可点击添加或移除这 {n} 个动作中的任意动作。",
+  "@pickedHint": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "pickAnExercise": "选择动作",
+  "searchAllExercises": "搜索动作…",
+  "noExercisesMatch": "没有匹配的动作",
+  "createItInstead": "改为创建自定义动作",
+  "startCount": "开始 · {n} 个动作",
+  "@startCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "inProgress": "训练中",
+  "paused": "已暂停",
+  "last": "上次",
+  "rest": "休息",
+  "skip": "跳过",
+  "addSet": "+ 添加一组",
+  "finishSession": "结束训练",
+  "setCol": "#",
+  "repsCol": "次数",
+  "weightCol": "重量 ({unit})",
+  "@weightCol": {
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "repsTitle": "次数",
+  "weightTitle": "重量 ({unit})",
+  "@weightTitle": {
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "sessionComplete": "训练已记录",
+  "finishHeadlinePr": "刷新个人纪录",
+  "finishHeadlineGoal": "达成本周目标",
+  "finishHeadlineStreak": "连续训练保持中",
+  "finishHeadlineDefault": "又完成一次训练",
+  "finishBodyPr": "你在 {prs} 个动作中刷新了历史最佳，现已记录。",
+  "@finishBodyPr": {
+    "placeholders": {
+      "prs": {
+        "type": "int"
+      }
+    }
+  },
+  "finishBodyGoal": "你完成了本周设定的训练次数。",
+  "finishBodyStreak": "已连续 {streak} 天。难的是坚持下去。",
+  "@finishBodyStreak": {
+    "placeholders": {
+      "streak": {
+        "type": "int"
+      }
+    }
+  },
+  "finishBodyDefault": "已记录并计入统计。稳定坚持才能带来进步。",
+  "vsLastTime": "与上次相比",
+  "firstTime": "首次记录",
+  "prCount": "{n} 项新纪录",
+  "@prCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "saveAndExit": "保存并退出",
+  "duration": "时长",
+  "setsCaps": "组数",
+  "exerciseXofY": "第 {i} 个动作，共 {n} 个",
+  "@exerciseXofY": {
+    "placeholders": {
+      "i": {
+        "type": "int"
+      },
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "decrease": "减少",
+  "increase": "增加",
+  "markSet": "将第 {n} 组标记为完成",
+  "@markSet": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "pauseWorkout": "暂停训练",
+  "resumeWorkout": "继续训练",
+  "discardTitle": "放弃本次训练？",
+  "discardBody": "本次训练记录的组数将丢失。",
+  "keepTraining": "继续训练",
+  "discard": "放弃",
+  "notifRestChannel": "组间休息计时",
+  "notifRestChannelWhy": "组间休息结束时提醒你",
+  "notifAlertChannel": "组间休息计时（提醒）",
+  "notifAlertChannelWhy": "休息结束时立即显示提醒横幅",
+  "restOverTitle": "休息结束",
+  "restOverBody": "继续训练，下一组等着你。",
+  "totalVolume30d": "总训练量 · 30 天",
+  "consistency": "坚持度",
+  "sessionsLogged": "已记录 {n} 次训练",
+  "@sessionsLogged": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "streakDays": "连续 {n} 天",
+  "@streakDays": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "bodyweight": "体重",
+  "notLoggedYet": "尚未记录",
+  "logShort": "+ 记录",
+  "logBodyweight": "记录体重",
+  "trackWeight": "跟踪体重变化",
+  "muscleMap": "肌群图",
+  "days7": "7天",
+  "days30": "30天",
+  "heatLow": "未训练",
+  "heatHigh": "训练量充足",
+  "muscleMapEmpty": "记录一次训练后，这里会显示肌群训练情况。",
+  "muscleMapHint": "点击肌群查看训练情况。",
+  "muscleMapBehind": "训练不足：{names}",
+  "@muscleMapBehind": {
+    "placeholders": {
+      "names": {
+        "type": "String"
+      }
+    }
+  },
+  "ofTarget": "目标的 {pct}%",
+  "@ofTarget": {
+    "placeholders": {
+      "pct": {
+        "type": "int"
+      }
+    }
+  },
+  "muscleSplit": "肌群分布",
+  "splitEmpty": "开始训练后可查看训练量在各肌群间的分布。",
+  "personalRecords": "个人纪录",
+  "prEmpty": "记录训练组后，你的纪录会显示在这里。",
+  "strength1rm": "力量 · 预计 1RM",
+  "strengthEmpty": "同一动作记录两次后，这里会显示力量曲线。",
+  "oneRmEst": "预计 1RM：{w}",
+  "@oneRmEst": {
+    "placeholders": {
+      "w": {
+        "type": "String"
+      }
+    }
+  },
+  "restDayShort": "休息日",
+  "restDay": "休息日 — 无训练记录。",
+  "tapToDelete": "点击垃圾桶可删除误记录的条目。",
+  "delete": "删除",
+  "deleteEntry": "删除此条目？",
+  "deleteEntryBody": "“{name}”将从当天记录、纪录和图表中删除。",
+  "@deleteEntryBody": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "bodyweightHistory": "历史",
+  "noBodyweightYet": "尚无记录。",
+  "exercisesCaps": "动作",
+  "timeCaps": "时间",
+  "libraryCount": "动作库中有 {n} 个动作",
+  "@libraryCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "searchExercises": "搜索动作",
+  "muscleFilter": "肌群",
+  "levelFilter": "难度",
+  "newExercise": "新建动作",
+  "exerciseName": "动作名称",
+  "equipmentLabel": "器械",
+  "addExercise": "添加动作",
+  "advanced": "高级",
+  "demoMedia": "演示",
+  "addMedia": "添加媒体",
+  "mediaHint": "图片、GIF 或视频",
+  "changeMedia": "更换",
+  "videoSelected": "已选择视频",
+  "favouritesOnly": "收藏",
+  "noFavouritesYet": "还没有收藏",
+  "noFavouritesHint": "点击动作上的星标即可收藏。",
+  "clearFilters": "清除筛选",
+  "noExercisesFound": "未找到动作",
+  "noExercisesHint": "尝试其他关键词或清除筛选条件。",
+  "personalRecord": "个人纪录",
+  "history": "历史",
+  "noHistory": "尚无训练记录。训练此动作后即可生成历史。",
+  "notes": "备注",
+  "notePlaceholder": "动作提示、设置、训练感受…",
+  "showAllNotes": "显示全部 {n} 条备注",
+  "@showAllNotes": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "showFewerNotes": "收起部分备注",
+  "moreNotes": "还有 {n} 条备注",
+  "@moreNotes": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "howTo": "动作说明",
+  "similar": "相似动作",
+  "primaryLabel": "主要肌群",
+  "secondaryLabel": "次要肌群",
+  "none": "无",
+  "setCount": "{n} 组",
+  "@setCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "volumeSuffix": "训练量 {v}",
+  "@volumeSuffix": {
+    "placeholders": {
+      "v": {
+        "type": "String"
+      }
+    }
+  },
+  "weeklyPlan": "每周计划",
+  "yourRoutines": "你的训练计划",
+  "noRoutines": "还没有训练计划。新建一个并添加动作吧。",
+  "newRoutine": "新建训练计划",
+  "routineName": "计划名称",
+  "schedule": "日程",
+  "addFromList": "从下方列表添加动作。",
+  "addExercises": "添加动作",
+  "deleteRoutine": "删除此训练计划？",
+  "exercisesWithCount": "动作 · {n}",
+  "@exercisesWithCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "setDay": "设置 {day}",
+  "@setDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "newRoutineName": "新训练计划",
+  "dragToReorder": "长按并拖动以调整顺序，这就是你的训练顺序。",
+  "reorderHandle": "调整 {name} 的顺序",
+  "@reorderHandle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "removeFromRoutine": "从计划中移除",
+  "dropExercise": "移除此动作？",
+  "dropExerciseBody": "“{name}”将从本次训练中移除，已有记录不会丢失。",
+  "@dropExerciseBody": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "drop": "移除",
+  "addToWorkout": "添加动作",
+  "resetData": "删除我的所有数据",
+  "resetTitle": "删除全部内容？",
+  "resetBody": "训练、纪录、计划、备注和个人资料都会被删除，且无法撤销。如可能需要，请先导出备份。",
+  "resetConfirm": "删除全部",
+  "resetDone": "所有数据已删除",
+  "support": "支持",
+  "reportBug": "报告问题",
+  "requestFeature": "提出功能建议",
+  "starOnGithub": "在 GitHub 点 Star",
+  "buyCoffee": "请我喝杯咖啡",
+  "cantOpenLink": "无法打开链接",
+  "preferences": "偏好设置",
+  "theme": "主题",
+  "darkTheme": "深色",
+  "lightTheme": "浅色",
+  "languageLabel": "语言",
+  "unitsLabel": "单位",
+  "restTimer": "休息计时",
+  "alarmBlockedTitle": "通知已关闭",
+  "alarmBlockedBody": "锁屏后休息提醒将不会响起",
+  "alarmBlockedAction": "开启",
+  "alarmSound": "提醒声音",
+  "alarmDefaultName": "默认",
+  "alarmSoundHint": "可使用自定义音频，最长 15 秒",
+  "alarmChoose": "选择声音…",
+  "alarmPreview": "播放当前声音",
+  "alarmReset": "恢复默认",
+  "alarmTooLong": "该音频超过 15 秒",
+  "alarmInvalid": "无法读取该音频文件",
+  "alarmChanged": "提醒声音已设为“{name}”",
+  "@alarmChanged": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "alarmChangedDefault": "已恢复默认声音",
+  "homeWidgets": "主屏幕",
+  "addActivityWidget": "添加活动小组件",
+  "addStatsWidget": "添加统计小组件",
+  "pinUnsupported": "请从桌面启动器的小组件菜单中添加",
+  "background": "背景",
+  "bgNone": "无",
+  "bgDots": "点阵",
+  "bgGrid": "网格",
+  "data": "数据",
+  "exportCsv": "导出训练记录（CSV）",
+  "exportBackup": "导出备份（JSON）",
+  "importBackup": "导入备份",
+  "importHint": "选择由 GymMane 导出的 .json 备份文件。导入后将替换当前数据。",
+  "import": "导入",
+  "chooseFile": "选择文件",
+  "importFromApp": "从其他应用导入",
+  "importUnknownFormat": "该文件不是 Hevy、Strong 或 FitNotes 的导出文件",
+  "importZipNoWeights": "该压缩包中没有体重文件",
+  "importWeights": "已导入 {n} 条体重记录",
+  "@importWeights": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "importReadFailed": "无法读取该文件",
+  "importUnitTitle": "该文件使用什么重量单位？",
+  "importUnitBody": "此导出文件没有注明重量单位。",
+  "importNothing": "没有可导入的新内容",
+  "importDone": "已导入 {n} 次训练",
+  "@importDone": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "aboutGymmane": "关于 GymMane",
+  "yourProfile": "你的资料",
+  "autofills": "用于自动填写计算器",
+  "nameLabel": "姓名",
+  "sexLabel": "性别",
+  "male": "男",
+  "female": "女",
+  "ageLabel": "年龄",
+  "heightLabel": "身高",
+  "weightLabel": "体重",
+  "weeklyGoal": "每周目标",
+  "activityLabel": "活动水平",
+  "addPhoto": "添加照片",
+  "removePhoto": "移除照片",
+  "takePhoto": "拍照",
+  "chooseGallery": "从相册选择",
+  "backupCopied": "备份已复制到剪贴板",
+  "backupImported": "备份已导入",
+  "backupFailed": "无法读取该备份",
+  "nothingToExport": "暂无可导出内容，请先记录一次训练",
+  "athlete": "训练者",
+  "calculatorsCount": "{n} 个训练计算器",
+  "@calculatorsCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "result": "结果",
+  "weightLifted": "所举重量",
+  "repsPerformed": "完成次数",
+  "neck": "颈围",
+  "waist": "腰围",
+  "hip": "臀围（女性）",
+  "targetWeight": "目标重量",
+  "workingWeight": "工作重量",
+  "activityLevel": "活动水平",
+  "barWeight": "杠铃杆重量",
+  "perSide": "每侧",
+  "justTheBar": "仅杠铃杆。",
+  "perSideCount": "每侧 × {n}",
+  "@perSideCount": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "rampSet": "{pct} · {reps} 次",
+  "@rampSet": {
+    "placeholders": {
+      "pct": {
+        "type": "String"
+      },
+      "reps": {
+        "type": "int"
+      }
+    }
+  },
+  "toolNameRm": "1RM",
+  "toolNameBmi": "BMI",
+  "toolNameCal": "热量",
+  "toolNameBf": "体脂",
+  "toolNamePlate": "杠铃片",
+  "toolNameWarmup": "热身",
+  "toolTitleRm": "1RM 计算器",
+  "toolTitleBmi": "BMI 计算器",
+  "toolTitleCal": "热量与宏量营养素",
+  "toolTitleBf": "体脂率",
+  "toolTitlePlate": "杠铃片计算器",
+  "toolTitleWarmup": "热身组",
+  "toolHintRm": "估算一次最大重量（Epley 公式）",
+  "toolHintCal": "估算每日维持热量",
+  "toolHintBf": "美国海军法估算",
+  "toolHintPlate": "杠铃总重量",
+  "toolHintWarmup": "目标工作重量",
+  "toolDescRm": "估算一次最大重量",
+  "toolDescBmi": "身体质量指数",
+  "toolDescCal": "热量与宏量营养素",
+  "toolDescBf": "体脂百分比",
+  "toolDescPlate": "杠铃片计算器",
+  "toolDescWarmup": "递增热身组",
+  "bmiUnderweight": "偏瘦",
+  "bmiNormal": "正常",
+  "bmiOverweight": "超重",
+  "bmiObese": "肥胖",
+  "actSedentary": "久坐",
+  "actLight": "轻度活动",
+  "actActive": "高活动量",
+  "actModerate": "中度活动",
+  "muscleChest": "胸肌",
+  "muscleBack": "背部",
+  "muscleShoulders": "肩部",
+  "muscleBiceps": "肱二头肌",
+  "muscleTriceps": "肱三头肌",
+  "muscleForearm": "前臂",
+  "muscleTrapezius": "斜方肌",
+  "muscleAbdomen": "腹肌",
+  "muscleObliques": "腹斜肌",
+  "muscleQuads": "股四头肌",
+  "muscleHamstrings": "腘绳肌",
+  "muscleGlutes": "臀肌",
+  "muscleCalves": "小腿",
+  "mgChest": "胸",
+  "mgBack": "背",
+  "mgLegs": "腿",
+  "mgShoulders": "肩",
+  "mgArms": "手臂",
+  "mgCore": "核心",
+  "equipBarbell": "杠铃",
+  "equipDumbbell": "哑铃",
+  "equipCable": "绳索",
+  "equipMachine": "器械",
+  "equipBodyweight": "自重",
+  "equipWeighted": "负重",
+  "equipBand": "弹力带",
+  "equipKettlebell": "壶铃",
+  "equipOther": "其他",
+  "diffBeginner": "初级",
+  "diffAdvanced": "高级",
+  "diffIntermediate": "中级",
+  "about": "关于",
+  "version": "版本 {v}",
+  "@version": {
+    "placeholders": {
+      "v": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutBlurb": "由训练者打造，为训练者而生。",
+  "freeForever": "永久免费",
+  "freeForeverWhy": "无订阅、无广告，也没有付费墙。",
+  "fullyOffline": "完全离线",
+  "fullyOfflineWhy": "无需账号、无需服务器，你的训练数据只留在这台手机上。",
+  "yoursToTake": "数据属于你",
+  "yoursToTakeWhy": "可随时导出为 CSV，也可一键全部删除。",
+  "whatsInside": "包含内容",
+  "exercisesInside": "{n} 个动作",
+  "@exercisesInside": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "exercisesInsideWhy": "每个动作都配有动画和分步说明。",
+  "calculatorsInside": "6 个计算器",
+  "calculatorsInsideWhy": "1RM、杠铃片、BMI、热量、体脂和热身，均采用公开公式。",
+  "mathInside": "真实计算",
+  "mathInsideWhy": "训练量、纪录和连续训练天数都来自你的实际训练组，不是装饰性的数字。",
+  "yourNumbers": "你的数据",
+  "sessionsCaps": "训练次数",
+  "liftedCaps": "总重量",
+  "streakCaps": "连续天数",
+  "daysUnit": "{n, plural, other{天}}",
+  "@daysUnit": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "restDefaultLabel": "休息计时",
+  "restDefault": "默认为 {s} 秒，可在设置中修改",
+  "@restDefault": {
+    "placeholders": {
+      "s": {
+        "type": "int"
+      }
+    }
+  },
+  "reset": "重置",
+  "welcomeKicker": "欢迎使用",
+  "welcomeBlurb": "所有数据都保存在你的手机上。无需账号、无需联网，也无需付费。",
+  "welcomeStart": "开始使用",
+  "onbStep": "第 {i} 步，共 {n} 步",
+  "@onbStep": {
+    "placeholders": {
+      "i": {
+        "type": "int"
+      },
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "onbNameTitle": "怎么称呼你？",
+  "onbNameHint": "你的名字",
+  "onbNameWhy": "仅用于称呼你，名字不会离开这台手机。",
+  "onbBodyTitle": "填写几个数据",
+  "onbBodyWhy": "这些数据用于计算器，你可以随时在设置中修改。",
+  "onbGoalTitle": "你每周训练几次？",
+  "onbGoalWhy": "用于设置每周目标。按实际情况填写，不必设得太激进。",
+  "perWeek": "每周 {n} 次训练",
+  "@perWeek": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
+  "onbUnitsTitle": "公斤还是磅？",
+  "next": "下一步",
+  "back": "返回",
+  "skip2": "跳过",
+  "artCredit": "动作插图由 Bryl Lim 和 Everkinetic 提供"
+}


### PR DESCRIPTION
## Summary

Adds Simplified Chinese UI localization for GymMane.

* adds `lib/l10n/app_zh.arb`
* translates the full app UI
* preserves all placeholders and ARB metadata
* does not modify the exercise catalogue or Dart source

## Scope

This PR intentionally covers app UI only. Exercise catalogue localization can be handled separately later.

## Validation

* ARB/JSON parses successfully
* all non-metadata strings from `app_en.arb` are translated
* placeholder-bearing strings were checked
* branch contains exactly one commit and one added file
