### PR TITLE
feat: pre-select recommended focus muscles when starting workout

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -428,7 +428,7 @@ class _FocusHero extends StatelessWidget {
                   const SizedBox(height: 8),
                   Text(subtitle, style: AppTheme.s(14, color: gc.textSecondary)),
                   const SizedBox(height: 20),
-                  PrimaryButton(label: t.startWorkout, icon: Ic.play, onTap: fit.startWorkout),
+                  PrimaryButton(label: t.startWorkout, icon: Ic.play, onTap: fit.startFocusWorkout),
                 ],
               ),
             ),

--- a/lib/state/workout_state.dart
+++ b/lib/state/workout_state.dart
@@ -11,10 +11,15 @@ mixin WorkoutState on FitCore, SettingsState, LibraryState, PlacesState, StatsSt
   int _elapsedBefore = 0;
   bool sessionPaused = false;
 
-  void startWorkout() {
+  void startWorkout([List<String>? initialMuscles]) {
+    selectedMuscles
+      ..clear()
+      ..addAll(initialMuscles ?? const []);
     trainStep = 'select';
     pushRoute('train');
   }
+
+  void startFocusWorkout() => startWorkout(suggestedFocus.muscles);
 
   List<Exercise> getFilteredExercises(List<String> sel) {
     if (sel.isEmpty) return const [];

--- a/test/flow_test.dart
+++ b/test/flow_test.dart
@@ -41,4 +41,24 @@ void main() {
 
     fit.saveAndExit();
   });
+
+  test('startFocusWorkout pre-selects suggested focus muscles and enters select step', () {
+    fit.sessions.clear();
+    fit.selectedMuscles.clear();
+    fit.route = 'home';
+
+    final suggested = fit.suggestedFocus;
+    expect(suggested.muscles, isNotEmpty);
+
+    fit.startFocusWorkout();
+
+    expect(fit.route, 'train');
+    expect(fit.trainStep, 'select');
+    expect(fit.selectedMuscles, suggested.muscles);
+
+    // Can proceed to review directly
+    fit.trainContinue();
+    expect(fit.trainStep, 'review');
+    expect(fit.sessionPicks, isNotEmpty);
+  });
 }


### PR DESCRIPTION
When tapping "START WORKOUT" on the Today's Focus hero card on the Home screen, pre-select the suggested focus muscles on the body map instead of opening an empty selection.

- Support optional initialMuscles in WorkoutState.startWorkout([initialMuscles])
- Add startFocusWorkout() helper targeting suggestedFocus.muscles
- Bind startFocusWorkout to Today's Focus card PrimaryButton
- Add unit test in flow_test.dart