### PR TITLE
Feat/exercise selection improvements

### DIFF
--- a/lib/screens/routine_edit_screen.dart
+++ b/lib/screens/routine_edit_screen.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-import '../catalog/exercise_catalog.dart';
 import '../l10n/l10n.dart';
 import '../models/exercise.dart';
-import '../services/exercise_match.dart';
 import '../state/fit_state.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_theme.dart';
+import '../widgets/exercise_filter_bar.dart';
 import '../widgets/exercise_media.dart';
 import '../widgets/svg_icon.dart';
 import '../widgets/ui_kit.dart';
@@ -25,6 +24,12 @@ class _RoutineEditScreenState extends State<RoutineEditScreen> {
       TextEditingController(text: fit.activeRoutine?.name ?? '');
   final TextEditingController _search = TextEditingController();
   String _q = '';
+  bool _favsOnly = false;
+  String? _placeId;
+  String? _muscle;
+  bool _noGearOnly = false;
+  String? _equipment;
+  String? _difficulty;
 
   @override
   void dispose() {
@@ -33,9 +38,32 @@ class _RoutineEditScreenState extends State<RoutineEditScreen> {
     super.dispose();
   }
 
+  void _clearFilters() {
+    _search.clear();
+    setState(() {
+      _q = '';
+      _favsOnly = false;
+      _placeId = null;
+      _muscle = null;
+      _noGearOnly = false;
+      _equipment = null;
+      _difficulty = null;
+    });
+  }
+
   List<Exercise> get _filtered {
-    if (_q.trim().isEmpty) return kExercises;
-    return kExercises.where(exerciseSearch(_q)).toList();
+    return filterExerciseList(
+      fit.allExercises,
+      query: _q,
+      favoritesOnly: _favsOnly,
+      favorites: fit.favorites,
+      placeId: _placeId,
+      places: fit.places,
+      muscleFilter: _muscle,
+      noGearOnly: _noGearOnly,
+      equipmentFilter: _equipment,
+      difficultyFilter: _difficulty,
+    );
   }
 
   @override
@@ -53,9 +81,29 @@ class _RoutineEditScreenState extends State<RoutineEditScreen> {
           Expanded(
             child: ListView.builder(
               padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
-              itemCount: list.length + 1,
+              itemCount: (list.isEmpty ? 1 : list.length) + 1,
               itemBuilder: (context, i) {
                 if (i == 0) return _header(gc, routine.exerciseIds.length);
+                if (list.isEmpty) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 36),
+                    child: Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(PhosphorIconsRegular.magnifyingGlass, size: 36, color: gc.textTertiary),
+                          const SizedBox(height: 10),
+                          Text(t.noExercisesFound,
+                              style: AppTheme.s(14, weight: FontWeight.w600, color: gc.text)),
+                          const SizedBox(height: 4),
+                          Text(t.noExercisesHint,
+                              textAlign: TextAlign.center,
+                              style: AppTheme.s(12, color: gc.textSecondary)),
+                        ],
+                      ),
+                    ),
+                  );
+                }
                 return _pickRow(gc, list[i - 1]);
               },
             ),
@@ -130,6 +178,7 @@ class _RoutineEditScreenState extends State<RoutineEditScreen> {
             shrinkWrap: true,
             buildDefaultDragHandles: false,
             physics: const NeverScrollableScrollPhysics(),
+            // ignore: deprecated_member_use
             onReorder: (from, to) => fit.reorderRoutineExercise(routine.id, from, to),
             children: [
               for (int i = 0; i < fit.routineExercises(routine).length; i++)
@@ -137,11 +186,33 @@ class _RoutineEditScreenState extends State<RoutineEditScreen> {
             ],
           ),
         ],
-        const SizedBox(height: 20),
-        SearchField(
-          controller: _search,
-          hint: t.addExercises,
-          onChanged: (v) => setState(() => _q = v),
+        const SizedBox(height: 16),
+        ExerciseFilterBar(
+          searchController: _search,
+          searchHint: t.addExercises,
+          onSearchChanged: (v) => setState(() => _q = v),
+          favoritesOnly: _favsOnly,
+          onToggleFavorites: () => setState(() => _favsOnly = !_favsOnly),
+          places: fit.places,
+          selectedPlaceId: _placeId,
+          onSelectPlace: (p) => setState(() => _placeId = p),
+          onManagePlaces: () => fit.goPlaces(),
+          selectedMuscle: _muscle,
+          onSelectMuscle: (m) => setState(() => _muscle = m),
+          noGearOnly: _noGearOnly,
+          onToggleNoGear: () => setState(() {
+            _noGearOnly = !_noGearOnly;
+            if (_noGearOnly) _equipment = null;
+          }),
+          selectedEquipment: _equipment,
+          onSelectEquipment: (e) => setState(() {
+            _equipment = e;
+            if (_equipment != null) _noGearOnly = false;
+          }),
+          selectedDifficulty: _difficulty,
+          onSelectDifficulty: (d) => setState(() => _difficulty = d),
+          favoriteCount: fit.favouriteCount,
+          onClearAll: _clearFilters,
         ),
         const SizedBox(height: 12),
       ],

--- a/lib/screens/train_screen.dart
+++ b/lib/screens/train_screen.dart
@@ -7,6 +7,7 @@ import '../state/fit_state.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_theme.dart';
 import '../widgets/body_map.dart';
+import '../widgets/exercise_filter_bar.dart';
 import '../widgets/exercise_media.dart';
 import '../widgets/svg_icon.dart';
 import '../widgets/ui_kit.dart';
@@ -22,10 +23,24 @@ class TrainScreen extends StatefulWidget {
 class _TrainScreenState extends State<TrainScreen> {
   final TextEditingController _searchCtrl = TextEditingController();
   String _q = '';
+  bool _favsOnly = false;
+  String? _placeId;
+  String? _muscle;
+  bool _noGearOnly = false;
+  String? _equipment;
+  String? _difficulty;
 
-  void _clearSearch() {
+  void _clearFilters() {
     _searchCtrl.clear();
-    setState(() => _q = '');
+    setState(() {
+      _q = '';
+      _favsOnly = false;
+      _placeId = null;
+      _muscle = null;
+      _noGearOnly = false;
+      _equipment = null;
+      _difficulty = null;
+    });
   }
 
   @override
@@ -146,16 +161,36 @@ class _TrainScreenState extends State<TrainScreen> {
   }
 
   Widget _review(BuildContext context, GymColors gc) {
-    final searching = _q.trim().isNotEmpty;
-
-    final exercises = searching ? fit.trainSearchResults(_q) : fit.reviewExercises();
+    final hasFilters = _q.trim().isNotEmpty ||
+        _favsOnly ||
+        (_placeId != null && _placeId!.isNotEmpty) ||
+        _muscle != null ||
+        _noGearOnly ||
+        _equipment != null ||
+        _difficulty != null;
+    final baseExercises = (_muscle != null || _q.trim().isNotEmpty) ? fit.allExercises : fit.reviewExercises();
+    final exercises = filterExerciseList(
+      baseExercises,
+      query: _q,
+      favoritesOnly: _favsOnly,
+      favorites: fit.favorites,
+      placeId: _placeId,
+      places: fit.places,
+      muscleFilter: _muscle,
+      noGearOnly: _noGearOnly,
+      equipmentFilter: _equipment,
+      difficultyFilter: _difficulty,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Row(
           children: [
             GestureDetector(
-              onTap: fit.trainBack,
+              onTap: () {
+                _clearFilters();
+                fit.trainBack();
+              },
               child: SvgPathIcon(Ic.chevronLeft, size: 20, color: gc.textSecondary),
             ),
             const SizedBox(width: 10),
@@ -169,15 +204,49 @@ class _TrainScreenState extends State<TrainScreen> {
           ],
         ),
         const SizedBox(height: 14),
-        _searchRow(context, gc),
+        ExerciseFilterBar(
+          searchController: _searchCtrl,
+          searchHint: t.searchAllExercises,
+          onSearchChanged: (v) => setState(() => _q = v),
+          favoritesOnly: _favsOnly,
+          onToggleFavorites: () => setState(() => _favsOnly = !_favsOnly),
+          places: fit.places,
+          selectedPlaceId: _placeId,
+          onSelectPlace: (p) => setState(() => _placeId = p),
+          onManagePlaces: () => fit.goPlaces(),
+          selectedMuscle: _muscle,
+          onSelectMuscle: (m) => setState(() => _muscle = m),
+          noGearOnly: _noGearOnly,
+          onToggleNoGear: () => setState(() {
+            _noGearOnly = !_noGearOnly;
+            if (_noGearOnly) _equipment = null;
+          }),
+          selectedEquipment: _equipment,
+          onSelectEquipment: (e) => setState(() {
+            _equipment = e;
+            if (_equipment != null) _noGearOnly = false;
+          }),
+          selectedDifficulty: _difficulty,
+          onSelectDifficulty: (d) => setState(() => _difficulty = d),
+          favoriteCount: fit.favouriteCount,
+          onClearAll: _clearFilters,
+          actions: [
+            _resetPicksBtn(gc),
+            _createExerciseBtn(context, gc),
+          ],
+        ),
         const SizedBox(height: 14),
-        if (!searching && exercises.isNotEmpty) ...[
+        if (!hasFilters && exercises.isNotEmpty) ...[
           Text(t.pickedHint(exercises.length),
+              style: AppTheme.s(12, color: gc.textTertiary)),
+          const SizedBox(height: 12),
+        ] else if (hasFilters && exercises.isNotEmpty) ...[
+          Text(t.libraryCount(exercises.length),
               style: AppTheme.s(12, color: gc.textTertiary)),
           const SizedBox(height: 12),
         ],
         if (exercises.isEmpty)
-          _emptyReview(context, gc, searching)
+          _emptyReview(context, gc, hasFilters)
         else
           for (final ex in exercises) ...[
             _pickRow(gc, ex),
@@ -187,85 +256,49 @@ class _TrainScreenState extends State<TrainScreen> {
     );
   }
 
-  Widget _searchRow(BuildContext context, GymColors gc) {
-    final hasQuery = _q.isNotEmpty;
-    return Row(
-      children: [
-        Expanded(
-          child: Container(
-            height: 48,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            decoration: BoxDecoration(
-              color: gc.bgRaised,
-              border: Border.all(color: gc.border),
-              borderRadius: BorderRadius.circular(100),
-            ),
-            child: Row(children: [
-              SvgPathIcon(Ic.search, size: 16, color: gc.textSecondary),
-              const SizedBox(width: 10),
-              Expanded(
-                child: TextField(
-                  controller: _searchCtrl,
-                  onChanged: (v) => setState(() => _q = v),
-                  style: AppTheme.s(14, color: gc.text),
-                  cursorColor: gc.accent,
-                  decoration: InputDecoration(
-                    isCollapsed: true,
-                    border: InputBorder.none,
-                    hintText: t.searchAllExercises,
-                    hintStyle: AppTheme.s(14, color: gc.textSecondary),
-                  ),
-                ),
-              ),
-              if (hasQuery)
-                GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onTap: _clearSearch,
-                  child: Padding(
-                    padding: const EdgeInsets.only(left: 6),
-                    child: SvgPathIcon(Ic.closeThin, size: 14, color: gc.textSecondary),
-                  ),
-                ),
-            ]),
-          ),
+  Widget _resetPicksBtn(GymColors gc) {
+    final hasPicks = fit.sessionPicks.isNotEmpty;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => setState(() => fit.toggleResetPicks()),
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          color: hasPicks ? gc.emberSoft : gc.bgRaised,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: hasPicks ? gc.ember.withValues(alpha: 0.3) : gc.border),
         ),
-        const SizedBox(width: 10),
-        GestureDetector(
-          onTap: fit.toggleResetPicks,
-          child: Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              color: gc.bgRaised,
-              borderRadius: BorderRadius.circular(14),
-              border: Border.all(color: gc.border),
-            ),
-            child: Icon(PhosphorIconsRegular.arrowCounterClockwise, size: 20, color: gc.textSecondary),
-          ),
+        child: Icon(
+          PhosphorIconsRegular.arrowCounterClockwise,
+          size: 20,
+          color: hasPicks ? gc.ember : gc.textTertiary,
         ),
-        const SizedBox(width: 10),
-        GestureDetector(
-          onTap: () => showCreateExerciseSheet(context, onCreated: (id) {
-            fit.togglePick(id);
-            _clearSearch();
-          }),
-          child: Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              color: gc.emberSoft,
-              borderRadius: BorderRadius.circular(14),
-              border: Border.all(color: gc.border),
-            ),
-            child: Icon(PhosphorIconsRegular.plus, size: 20, color: gc.ember),
-          ),
-        ),
-      ],
+      ),
     );
   }
 
-  Widget _emptyReview(BuildContext context, GymColors gc, bool searching) {
-    if (searching) {
+  Widget _createExerciseBtn(BuildContext context, GymColors gc) {
+    return GestureDetector(
+      onTap: () => showCreateExerciseSheet(context, onCreated: (id) {
+        fit.togglePick(id);
+        _clearFilters();
+      }),
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          color: gc.emberSoft,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: gc.border),
+        ),
+        child: Icon(PhosphorIconsRegular.plus, size: 20, color: gc.ember),
+      ),
+    );
+  }
+
+  Widget _emptyReview(BuildContext context, GymColors gc, bool hasFilters) {
+    if (hasFilters) {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
         child: Column(
@@ -277,7 +310,7 @@ class _TrainScreenState extends State<TrainScreen> {
               behavior: HitTestBehavior.opaque,
               onTap: () => showCreateExerciseSheet(context, onCreated: (id) {
                 fit.togglePick(id);
-                _clearSearch();
+                _clearFilters();
               }),
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/lib/screens/train_screen.dart
+++ b/lib/screens/train_screen.dart
@@ -231,6 +231,20 @@ class _TrainScreenState extends State<TrainScreen> {
         ),
         const SizedBox(width: 10),
         GestureDetector(
+          onTap: fit.toggleResetPicks,
+          child: Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: gc.bgRaised,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: gc.border),
+            ),
+            child: Icon(PhosphorIconsRegular.arrowCounterClockwise, size: 20, color: gc.textSecondary),
+          ),
+        ),
+        const SizedBox(width: 10),
+        GestureDetector(
           onTap: () => showCreateExerciseSheet(context, onCreated: (id) {
             fit.togglePick(id);
             _clearSearch();

--- a/lib/state/workout_state.dart
+++ b/lib/state/workout_state.dart
@@ -94,6 +94,26 @@ mixin WorkoutState on FitCore, SettingsState, LibraryState, PlacesState, StatsSt
 
   bool isPicked(String id) => sessionPicks.contains(id);
 
+  void clearPicks() {
+    sessionPicks.clear();
+    notifyListeners();
+  }
+
+  void resetDefaultPicks() {
+    sessionPicks
+      ..clear()
+      ..addAll(_defaultPicks(selectedMuscles).map((e) => e.id));
+    notifyListeners();
+  }
+
+  void toggleResetPicks() {
+    if (sessionPicks.isNotEmpty) {
+      clearPicks();
+    } else {
+      resetDefaultPicks();
+    }
+  }
+
   void trainBack() {
     trainStep = 'select';
     notifyListeners();

--- a/lib/widgets/exercise_filter_bar.dart
+++ b/lib/widgets/exercise_filter_bar.dart
@@ -1,0 +1,361 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../catalog/exercise_catalog.dart';
+import '../l10n/l10n.dart';
+import '../models/exercise.dart';
+import '../models/place.dart';
+import '../services/exercise_match.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_theme.dart';
+import 'svg_icon.dart';
+import 'ui_kit.dart';
+
+/// Pure filtering function matching the logic across GymMane
+List<Exercise> filterExerciseList(
+  List<Exercise> exercises, {
+  String query = '',
+  bool favoritesOnly = false,
+  Map<String, bool> favorites = const {},
+  String? placeId,
+  List<GymPlace> places = const [],
+  String? muscleFilter,
+  bool noGearOnly = false,
+  String? equipmentFilter,
+  String? difficultyFilter,
+}) {
+  final q = query.trim().toLowerCase();
+  final matchFn = q.isNotEmpty ? exerciseSearch(q) : null;
+  final GymPlace? activePlace = (placeId != null && placeId.isNotEmpty)
+      ? places.where((p) => p.id == placeId).firstOrNull
+      : null;
+  final Set<String>? gearHere =
+      activePlace == null ? null : {...activePlace.equipment, 'Bodyweight'};
+
+  return exercises.where((ex) {
+    if (favoritesOnly && favorites[ex.id] != true) return false;
+    if (matchFn != null) {
+      final zh = exerciseName(ex).toLowerCase();
+      final mus = muscleLabel(ex.primary).toLowerCase();
+      if (!matchFn(ex) && !zh.contains(q) && !mus.contains(q)) return false;
+    }
+    if (gearHere != null && !gearHere.contains(ex.equipment)) {
+      return false;
+    }
+    if (muscleFilter != null &&
+        ex.primary != muscleFilter &&
+        !ex.secondary.contains(muscleFilter)) {
+      return false;
+    }
+    if (noGearOnly && ex.equipment != 'Bodyweight') {
+      return false;
+    }
+    if (equipmentFilter != null && ex.equipment != equipmentFilter) {
+      return false;
+    }
+    if (difficultyFilter != null && ex.difficulty != difficultyFilter) {
+      return false;
+    }
+    return true;
+  }).toList();
+}
+
+class _FilterChipItem {
+  const _FilterChipItem(this.label, this.active, this.onTap);
+  final String label;
+  final bool active;
+  final VoidCallback onTap;
+}
+
+/// Reusable filter bar with Search input, Favorites toggle, Place chips,
+/// Muscle group pills, Equipment pills, and Difficulty pills.
+class ExerciseFilterBar extends StatelessWidget {
+  const ExerciseFilterBar({
+    super.key,
+    required this.searchController,
+    required this.onSearchChanged,
+    required this.favoritesOnly,
+    required this.onToggleFavorites,
+    this.places = const [],
+    this.selectedPlaceId,
+    this.onSelectPlace,
+    this.onManagePlaces,
+    required this.selectedMuscle,
+    required this.onSelectMuscle,
+    this.noGearOnly = false,
+    this.onToggleNoGear,
+    this.selectedEquipment,
+    this.onSelectEquipment,
+    required this.selectedDifficulty,
+    required this.onSelectDifficulty,
+    this.searchHint,
+    this.favoriteCount = 0,
+    this.onClearAll,
+    this.actions,
+  });
+
+  final TextEditingController searchController;
+  final ValueChanged<String> onSearchChanged;
+  final bool favoritesOnly;
+  final VoidCallback onToggleFavorites;
+
+  final List<GymPlace> places;
+  final String? selectedPlaceId;
+  final ValueChanged<String?>? onSelectPlace;
+  final VoidCallback? onManagePlaces;
+
+  final String? selectedMuscle;
+  final ValueChanged<String?> onSelectMuscle;
+
+  final bool noGearOnly;
+  final VoidCallback? onToggleNoGear;
+  final String? selectedEquipment;
+  final ValueChanged<String?>? onSelectEquipment;
+
+  final String? selectedDifficulty;
+  final ValueChanged<String?> onSelectDifficulty;
+
+  final String? searchHint;
+  final int favoriteCount;
+  final VoidCallback? onClearAll;
+  final List<Widget>? actions;
+
+  bool get hasActiveFilter =>
+      searchController.text.isNotEmpty ||
+      favoritesOnly ||
+      (selectedPlaceId != null && selectedPlaceId!.isNotEmpty) ||
+      selectedMuscle != null ||
+      noGearOnly ||
+      selectedEquipment != null ||
+      selectedDifficulty != null;
+
+  Widget _sectionHeader(GymColors gc, String label, {bool showClear = false}) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label,
+            style: AppTheme.s(10, weight: FontWeight.w700, color: gc.textTertiary, letterSpacing: 1.5)),
+        if (showClear && hasActiveFilter && onClearAll != null)
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onClearAll,
+            child: Text(t.clearFilters,
+                style: AppTheme.s(11, weight: FontWeight.w600, color: gc.accent)),
+          ),
+      ],
+    );
+  }
+
+  Widget _chipRow(
+    List<_FilterChipItem> items,
+    GymColors gc, {
+    required double hPad,
+    required double vPad,
+    required double fontSize,
+  }) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(children: [
+        for (int i = 0; i < items.length; i++) ...[
+          Pill(
+            label: items[i].label,
+            bg: items[i].active ? gc.ember : gc.bgRaised2,
+            fg: items[i].active ? gc.onEmber : gc.textSecondary,
+            onTap: items[i].onTap,
+            hPad: hPad,
+            vPad: vPad,
+            fontSize: fontSize,
+          ),
+          if (i < items.length - 1) const SizedBox(width: 8),
+        ],
+      ]),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final gc = context.gc;
+    final showPlaces = onSelectPlace != null;
+    final showEquipment = onSelectEquipment != null || onToggleNoGear != null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Search bar and optional actions
+        Row(
+          children: [
+            Expanded(
+              child: Container(
+                height: 48,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                decoration: BoxDecoration(
+                  color: gc.bgRaised,
+                  border: Border.all(color: gc.border),
+                  borderRadius: BorderRadius.circular(100),
+                ),
+                child: Row(children: [
+                  SvgPathIcon(Ic.search, size: 16, color: gc.textSecondary),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: TextField(
+                      controller: searchController,
+                      onChanged: onSearchChanged,
+                      style: AppTheme.s(14, color: gc.text),
+                      cursorColor: gc.accent,
+                      decoration: InputDecoration(
+                        isCollapsed: true,
+                        border: InputBorder.none,
+                        hintText: searchHint ?? t.searchExercises,
+                        hintStyle: AppTheme.s(14, color: gc.textSecondary),
+                      ),
+                    ),
+                  ),
+                  if (searchController.text.isNotEmpty)
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () {
+                        searchController.clear();
+                        onSearchChanged('');
+                      },
+                      child: Padding(
+                        padding: const EdgeInsets.all(4),
+                        child: Icon(PhosphorIconsRegular.xCircle, size: 18, color: gc.textTertiary),
+                      ),
+                    ),
+                ]),
+              ),
+            ),
+            if (actions != null && actions!.isNotEmpty) ...[
+              for (final action in actions!) ...[
+                const SizedBox(width: 10),
+                action,
+              ],
+            ],
+          ],
+        ),
+        const SizedBox(height: 12),
+
+        // Favorites toggle
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onToggleFavorites,
+          child: Semantics(
+            button: true,
+            selected: favoritesOnly,
+            child: Container(
+              height: 44,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: favoritesOnly ? gc.accentSoft : Colors.transparent,
+                border: Border.all(color: favoritesOnly ? gc.accent : gc.border),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: Stack(children: [
+                      if (favoritesOnly)
+                        SvgPathIcon(const [
+                          IconPath(
+                              'M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 21 12 17.77 5.82 21 7 14.14l-5-4.87 6.91-1.01z',
+                              fill: true)
+                        ], size: 18, color: gc.accent),
+                      SvgPathIcon(Ic.star, size: 18, color: favoritesOnly ? gc.accent : gc.textTertiary),
+                    ]),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    favoriteCount > 0
+                        ? '${t.favouritesOnly.toUpperCase()} · $favoriteCount'
+                        : t.favouritesOnly.toUpperCase(),
+                    style: AppTheme.d(12,
+                        weight: FontWeight.w600,
+                        color: favoritesOnly ? gc.accent : gc.text,
+                        letterSpacing: 1),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        // Place filter chips (if enabled)
+        if (showPlaces) ...[
+          _sectionHeader(gc, t.placeFilterLabel, showClear: true),
+          const SizedBox(height: 8),
+          _chipRow([
+            _FilterChipItem(
+              t.placeAll,
+              selectedPlaceId == null || selectedPlaceId!.isEmpty,
+              () => onSelectPlace?.call(null),
+            ),
+            for (final place in places)
+              _FilterChipItem(
+                place.name,
+                selectedPlaceId == place.id,
+                () => onSelectPlace?.call(selectedPlaceId == place.id ? null : place.id),
+              ),
+            if (onManagePlaces != null)
+              _FilterChipItem(
+                places.isEmpty ? t.placeNew : '+',
+                false,
+                onManagePlaces!,
+              ),
+          ], gc, hPad: 14, vPad: 8, fontSize: 13),
+          const SizedBox(height: 12),
+        ],
+
+        // Muscle filter chips
+        _sectionHeader(gc, t.muscleFilter, showClear: !showPlaces),
+        const SizedBox(height: 8),
+        _chipRow([
+          for (final id in kFilterMuscles)
+            _FilterChipItem(
+              muscleLabel(id),
+              selectedMuscle == id,
+              () => onSelectMuscle(selectedMuscle == id ? null : id),
+            ),
+        ], gc, hPad: 14, vPad: 8, fontSize: 13),
+        const SizedBox(height: 12),
+
+        // Equipment filter chips (if enabled)
+        if (showEquipment) ...[
+          _sectionHeader(gc, t.equipmentLabel),
+          const SizedBox(height: 8),
+          _chipRow([
+            if (onToggleNoGear != null)
+              _FilterChipItem(
+                t.noGearOnly,
+                noGearOnly,
+                onToggleNoGear!,
+              ),
+            for (final e in kFilterEquipment)
+              _FilterChipItem(
+                t.equipment(e),
+                selectedEquipment == e,
+                () => onSelectEquipment?.call(selectedEquipment == e ? null : e),
+              ),
+          ], gc, hPad: 12, vPad: 6, fontSize: 12),
+          const SizedBox(height: 12),
+        ],
+
+        // Level filter chips
+        _sectionHeader(gc, t.levelFilter),
+        const SizedBox(height: 8),
+        _chipRow([
+          for (final d in kDifficulties)
+            _FilterChipItem(
+              t.difficulty(d),
+              selectedDifficulty == d,
+              () => onSelectDifficulty(selectedDifficulty == d ? null : d),
+            ),
+        ], gc, hPad: 12, vPad: 6, fontSize: 12),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+}

--- a/test/exercise_filter_test.dart
+++ b/test/exercise_filter_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gymmane/catalog/exercise_catalog.dart';
+import 'package:gymmane/models/place.dart';
+import 'package:gymmane/widgets/exercise_filter_bar.dart';
+
+void main() {
+  test('filterExerciseList filters by query (name or muscle)', () {
+    final list = filterExerciseList(kExercises, query: 'bench press');
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.name.toLowerCase().contains('bench') || e.primary.toLowerCase().contains('bench'), true);
+    }
+  });
+
+  test('filterExerciseList filters by favorites only', () {
+    final favId = kExercises.first.id;
+    final list = filterExerciseList(
+      kExercises,
+      favoritesOnly: true,
+      favorites: {favId: true},
+    );
+    expect(list.length, 1);
+    expect(list.first.id, favId);
+  });
+
+  test('filterExerciseList filters by muscle group', () {
+    final list = filterExerciseList(kExercises, muscleFilter: 'chest');
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.primary == 'chest' || e.secondary.contains('chest'), true);
+    }
+  });
+
+  test('filterExerciseList filters by difficulty level', () {
+    final list = filterExerciseList(kExercises, difficultyFilter: 'Beginner');
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.difficulty, 'Beginner');
+    }
+  });
+
+  test('filterExerciseList filters by noGearOnly (Bodyweight only)', () {
+    final list = filterExerciseList(kExercises, noGearOnly: true);
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.equipment, 'Bodyweight');
+    }
+  });
+
+  test('filterExerciseList filters by equipmentFilter', () {
+    final list = filterExerciseList(kExercises, equipmentFilter: 'Dumbbell');
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.equipment, 'Dumbbell');
+    }
+  });
+
+  test('filterExerciseList filters by place (gear in place + Bodyweight)', () {
+    final homePlace = GymPlace(id: 'home_1', name: 'Home', equipment: {'Dumbbell', 'Band'});
+    final list = filterExerciseList(
+      kExercises,
+      placeId: 'home_1',
+      places: [homePlace],
+    );
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.equipment == 'Dumbbell' || e.equipment == 'Band' || e.equipment == 'Bodyweight', true);
+    }
+  });
+
+  test('filterExerciseList combines multiple filters cleanly', () {
+    final homePlace = GymPlace(id: 'home_1', name: 'Home', equipment: {'Dumbbell', 'Band'});
+    final list = filterExerciseList(
+      kExercises,
+      placeId: 'home_1',
+      places: [homePlace],
+      muscleFilter: 'chest',
+      equipmentFilter: 'Dumbbell',
+      difficultyFilter: 'Beginner',
+      query: 'press',
+    );
+    for (final e in list) {
+      expect(e.primary == 'chest' || e.secondary.contains('chest'), true);
+      expect(e.difficulty, 'Beginner');
+      expect(e.equipment, 'Dumbbell');
+      expect(e.name.toLowerCase().contains('press'), true);
+    }
+  });
+
+  test('filterExerciseList supports exercise abbreviation aliases', () {
+    final list = filterExerciseList(kExercises, query: 'db bench');
+    expect(list.isNotEmpty, true);
+    for (final e in list) {
+      expect(e.name.toLowerCase().contains('dumbbell') && e.name.toLowerCase().contains('bench'), true);
+    }
+  });
+}

--- a/test/flow_test.dart
+++ b/test/flow_test.dart
@@ -61,4 +61,30 @@ void main() {
     expect(fit.trainStep, 'review');
     expect(fit.sessionPicks, isNotEmpty);
   });
+
+  test('toggleResetPicks clears picks when non-empty, and restores defaults when empty', () {
+    fit.sessions.clear();
+    fit.selectedMuscles.clear();
+    fit.startFocusWorkout();
+    fit.trainContinue();
+
+    expect(fit.sessionPicks, isNotEmpty);
+    final defaultCount = fit.sessionPicks.length;
+
+    // First toggle: clears all picks
+    fit.toggleResetPicks();
+    expect(fit.sessionPicks, isEmpty);
+
+    // Second toggle: restores default picks
+    fit.toggleResetPicks();
+    expect(fit.sessionPicks.length, defaultCount);
+
+    // Direct clearPicks
+    fit.clearPicks();
+    expect(fit.sessionPicks, isEmpty);
+
+    // Direct resetDefaultPicks
+    fit.resetDefaultPicks();
+    expect(fit.sessionPicks.length, defaultCount);
+  });
 }

--- a/test/train_step2_test.dart
+++ b/test/train_step2_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gymmane/app/gymmane_app.dart';
+import 'package:gymmane/state/fit_state.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+void main() {
+  testWidgets('TrainScreen step 2 displays reset picks button and toggles selection', (tester) async {
+    fit.onboarded = true;
+    fit.selectedMuscles.clear();
+    fit.selectedMuscles.addAll(['chest', 'triceps']);
+    fit.trainContinue();
+    fit.route = 'train';
+
+    await tester.pumpWidget(const GymManeApp());
+    await tester.pumpAndSettle();
+
+    // Verify Reset button icon is present
+    expect(find.byIcon(PhosphorIconsRegular.arrowCounterClockwise), findsOneWidget);
+
+    // Verify Plus button icon is present
+    expect(find.byIcon(PhosphorIconsRegular.plus), findsOneWidget);
+
+    // Verify picks initially non-empty
+    expect(fit.sessionPicks.isNotEmpty, true);
+
+    // Tap reset button -> clears picks
+    await tester.tap(find.byIcon(PhosphorIconsRegular.arrowCounterClockwise));
+    await tester.pumpAndSettle();
+    expect(fit.sessionPicks.isEmpty, true);
+
+    // Tap reset button again -> restores default picks
+    await tester.tap(find.byIcon(PhosphorIconsRegular.arrowCounterClockwise));
+    await tester.pumpAndSettle();
+    expect(fit.sessionPicks.isNotEmpty, true);
+
+    fit.route = 'home';
+  });
+}

--- a/test/train_step2_test.dart
+++ b/test/train_step2_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gymmane/app/gymmane_app.dart';
 import 'package:gymmane/state/fit_state.dart';
+import 'package:gymmane/widgets/exercise_filter_bar.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 void main() {
-  testWidgets('TrainScreen step 2 displays reset picks button and toggles selection', (tester) async {
+  testWidgets('TrainScreen step 2 displays ExerciseFilterBar and reset button', (tester) async {
     fit.onboarded = true;
     fit.selectedMuscles.clear();
     fit.selectedMuscles.addAll(['chest', 'triceps']);
@@ -13,6 +14,9 @@ void main() {
 
     await tester.pumpWidget(const GymManeApp());
     await tester.pumpAndSettle();
+
+    // Verify ExerciseFilterBar is present
+    expect(find.byType(ExerciseFilterBar), findsOneWidget);
 
     // Verify Reset button icon is present
     expect(find.byIcon(PhosphorIconsRegular.arrowCounterClockwise), findsOneWidget);


### PR DESCRIPTION
### Summary
This PR improves exercise selection across the app with two key features:
1. **One-tap Clear & Restore Picks Button**: Adds a smart reset button (`arrowCounterClockwise`) in Step 2 of workout creation (`TrainScreen`). Tapping it clears all picks for a blank slate; tapping again restores default recommendations.
2. **Reusable 6-Dimensional Filter Bar**: Extracts `ExerciseFilterBar` and `filterExerciseList` matching 1.1.0 Exercise Library capabilities (Search query with aliases, Favorites, Places, Target Muscles, Equipment with bodyweight exclusivity, and Difficulty). Now shared between `TrainScreen` and `RoutineEditScreen`.

Closes #23

---

### Screenshots

| Workout Creation (Step 2) | Routine Edit Screen |
| :---: | :---: |
| <img width="300" height="600" alt="Snipaste_2026-09-10_22-18-37" src="https://github.com/user-attachments/assets/fbfb04bb-58db-40e9-830f-c9311361ee0b" />| <img width="300" height="600" alt="Snipaste_2026-09-10_22-21-49" src="https://github.com/user-attachments/assets/2feea028-e16a-46c7-988e-81e659916523" />
 |


---

### Key Changes
- **`WorkoutState`**: Added `clearPicks()`, `resetDefaultPicks()`, and `toggleResetPicks()`.
- **`ExerciseFilterBar` & `filterExerciseList`**: Extracted reusable component matching GymMane design system (`context.gc`, `AppTheme`, `Pill`) and pure filtering algorithm with native alias support (`db`, `bb`, `rdl`, etc.).
- **`TrainScreen` & `RoutineEditScreen`**: Replaced fragmented search inputs with the unified 6-dimensional filter bar; embedded the reset button and "+ New Exercise" in the action slot.
- **Tests**: Added 9 unit tests in `test/exercise_filter_test.dart`, plus state and widget test coverage in `test/flow_test.dart` and `test/train_step2_test.dart`.

---

### Verification
- `flutter analyze`: Passed (0 issues).
- `flutter test`: Passed (all 341 tests passing).